### PR TITLE
 build: link SeaStar with POSIX threads library. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -572,6 +572,7 @@ target_link_libraries (seastar
     cryptopp::cryptopp
     fmt::fmt
     lz4::lz4
+    pthread
   PRIVATE
     ${CMAKE_DL_LIBS}
     Boost::filesystem


### PR DESCRIPTION
It looks SeaStar isn't linking with pthreads while making extensive use of its procedures (like `pthread setname_np` in `src/core/reactor.cc` which was causing linking errors on my machine). I would kindly ask for a local review before going with this patch to the upstream.