### PR TITLE
posix_data_source_impl: adaptive prefetch size

### DIFF
--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -109,7 +109,7 @@ class posix_data_source_impl final : public data_source_impl {
     size_t _buf_size;
 public:
     explicit posix_data_source_impl(lw_shared_ptr<pollable_fd> fd, compat::polymorphic_allocator<char>* allocator=memory::malloc_allocator,
-        size_t buf_size = 8192) : _buffer_allocator(allocator), _fd(std::move(fd)),
+        size_t buf_size = 1 << 13) : _buffer_allocator(allocator), _fd(std::move(fd)),
         _buf(make_temporary_buffer<char>(_buffer_allocator, buf_size)), _buf_size(buf_size) {}
     future<temporary_buffer<char>> get() override;
     future<> close() override;


### PR DESCRIPTION
~~4K & depth=1 case will be a little slower because `ceph::net::posix_data_source_impl` will always allocate 64K sized buffer for prefetch (https://github.com/ceph/seastar/blob/master/net/posix-stack.cc#L286), but there are at most 4K data on the wire if the depth is 1. And it isn't common case. For other cases, the performance will be notably better, because of larger prefetched buffer.~~

Implemented adaptive prefetch buffer based on last read size:
* No magic number needed to be configured any more.
* Won't waste memory space when there are not that much to prefetch.
* Can have bigger prefetch buffer instantly whenever needed.

2-way 4K read/write
----

saturated connection (throughput):
`$perf_crimson_msgr --round=4194304 --cbs=4096 --sbs=4096 --depth=512 -c 3`

 run | 1st | 2nd | 3rd 
---|---|---|---
fixed 8K (reference point) | 18.4555s | 18.5185s | 18.4318s
fixed 64K | 17.5711s | 17.6602s | 17.694s
adaptive | 17.11s | 17.21s | 17.28s

depth=1 (latency):
`$perf_crimson_msgr --round=1048576 --cbs=4096 --sbs=4096 --depth=1 -c 3`

 run | 1st | 2nd | 3rd 
---|---|---|---
fixed 8K (reference point) | 20.48s | 20.47s | 20.64s
fixed 64K | 21.3099s | 21.2366s | 21.2861s
adaptive | 20.52s | 20.28s | 20.41s

2-way 1M read/write
----

saturated connection (throughput):
`$perf_crimson_msgr --round=65536 --cbs=1048576 --sbs=1048576 --depth=512 -c 3`

 run | 1st | 2nd | 3rd 
---|---|---|---
fixed 8K (reference point) | 24.7577s | 24.8432s | 24.8043s
fixed 64K | 18.5113s | 18.4522s | 18.4962s
adaptive | 17.92s | 17.66s | 17.83s

depth=1 (latency):
`$perf_crimson_msgr --round=65536 --cbs=1048576 --sbs=1048576 --depth=1 -c 3 `

 run | 1st | 2nd | 3rd 
---|---|---|---
fixed 8K (reference point) | 31.0175s | 30.9355s | 30.8921s
fixed 64K | 19.9777s | 19.9308s | 19.9492s
adaptive | 19.73s | 19.63s | 19.68s