### PR TITLE
[RFC] iostream: extended read_exactly2 interface with alignment

### DIFF
--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -112,6 +112,7 @@ public:
         size_t buf_size = 8192) : _buffer_allocator(allocator), _fd(std::move(fd)),
         _buf(make_temporary_buffer<char>(_buffer_allocator, buf_size)), _buf_size(buf_size) {}
     future<temporary_buffer<char>> get() override;
+    future<size_t, temporary_buffer<char>> get_direct(char* buf, size_t size) override;
     future<> close() override;
 };
 

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -109,7 +109,7 @@ class posix_data_source_impl final : public data_source_impl {
     size_t _buf_size;
 public:
     explicit posix_data_source_impl(lw_shared_ptr<pollable_fd> fd, compat::polymorphic_allocator<char>* allocator=memory::malloc_allocator,
-        size_t buf_size = 8192) : _buffer_allocator(allocator), _fd(std::move(fd)),
+        size_t buf_size = 1 << 13) : _buffer_allocator(allocator), _fd(std::move(fd)),
         _buf(make_temporary_buffer<char>(_buffer_allocator, buf_size)), _buf_size(buf_size) {}
     future<temporary_buffer<char>> get() override;
     future<size_t, temporary_buffer<char>> get_direct(char* buf, size_t size) override;


### PR DESCRIPTION
See https://gist.github.com/cyx1231st/57727c8aa6c98ed48a8b06d64b7923d7

This PR introduces a less intrusive way to implement read with alignment.

Considerations:
* Less intrusive: it only **adds** code to the existing seastar, and all the existing interfaces are fully functional with no impact.
* For `posix_data_source_impl`, system-call is assumed to be much more expensive than memory-copy, so the prefetch is disabled only if:
  - The read is not allowed to be scattered because of alignment requirement.
  - And, the read size is large enough to be worthwhile to trigger an exclusive syscall.
(This idea is very similar to the current async-msgr, which will always do prefetch if the read is not large enough, and copy the prefetched data to the out buffer `p`, see https://github.com/ceph/ceph/blob/master/src/msg/async/AsyncConnection.cc#L235-L271)
* For `native_data_source_impl`, the current implementation will try its best to verify if the memory alignment is already good, and will trigger user-to-user-space copy only if required. 
* For the rest `*_data_source_impl`, they are simply compatible and we currently haven't used them.


The code is functioning now, but still needs further evaluation of performance impacts.