### PR TITLE
[DNM] Server-side support for UNIX-domain stream sockets

### DIFF
--- a/include/seastar/core/posix.hh
+++ b/include/seastar/core/posix.hh
@@ -248,6 +248,10 @@ public:
         auto r = ::bind(_fd, &sa, sl);
         throw_system_error_on(r == -1, "bind");
     }
+    void unixdomain_bind(sockaddr_un sa) {
+        auto r = ::bind(_fd, (struct sockaddr *)&sa, sizeof(sockaddr_un));
+        throw_system_error_on(r == -1, "bind");
+    }
     void connect(sockaddr& sa, socklen_t sl) {
         auto r = ::connect(_fd, &sa, sl);
         if (r == -1 && errno == EINPROGRESS) {

--- a/include/seastar/core/sharded.hh
+++ b/include/seastar/core/sharded.hh
@@ -89,7 +89,7 @@ public:
 class no_sharded_instance_exception : public std::exception {
 public:
     virtual const char* what() const noexcept override {
-        return "sharded instance does not exists";
+        return "sharded instance does not exist";
     }
 };
 

--- a/include/seastar/net/posix-stack.hh
+++ b/include/seastar/net/posix-stack.hh
@@ -149,6 +149,7 @@ public:
 };
 using posix_tcp_ap_server_socket_impl = posix_ap_server_socket_impl<transport::TCP>;
 using posix_sctp_ap_server_socket_impl = posix_ap_server_socket_impl<transport::SCTP>;
+using posix_unix_ap_server_socket_impl = posix_ap_server_socket_impl<transport::UNIX>;
 
 template <transport Transport>
 class posix_server_socket_impl : public server_socket_impl {
@@ -166,6 +167,7 @@ public:
 };
 using posix_server_tcp_socket_impl = posix_server_socket_impl<transport::TCP>;
 using posix_server_sctp_socket_impl = posix_server_socket_impl<transport::SCTP>;
+using posix_server_unix_socket_impl = posix_server_socket_impl<transport::UNIX>;
 
 template <transport Transport>
 class posix_reuseport_server_socket_impl : public server_socket_impl {

--- a/src/core/alien.cc
+++ b/src/core/alien.cc
@@ -75,7 +75,7 @@ size_t message_queue::process_queue(lf_queue& q, Func process) {
         ++nr;
     }
     std::fill(std::begin(items) + nr, std::begin(items) + nr + prefetch_cnt, nr ? items[nr - 1] : wi);
-    unsigned i = 0;
+    size_t i = 0;
     do {
         prefetch_n<2>(std::begin(items) + i, std::begin(items) + i + prefetch_cnt);
         process(wi);

--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -190,6 +190,17 @@ socket_address::socket_address(const ipv6_addr& addr)
     std::copy(addr.ip.begin(), addr.ip.end(), u.in6.sin6_addr.s6_addr);
 }
 
+socket_address::socket_address(const ud_addr& addr)
+{
+    u.un.sun_family = AF_UNIX;
+    
+    //  Note: I am limiting the socket name to 107, while Linux supports
+    //  the non-portable limit of 108 (allowing strings without the terminating
+    //  '\0'. 
+    strncpy(u.un.sun_path, addr.sfile_.c_str(), sizeof(u.un.sun_path)-1);
+    u.un.sun_path[sizeof(u.un.sun_path)-1] = '\0';
+}
+    
 socket_address::socket_address(uint32_t ipv4, uint16_t p)
     : socket_address(make_ipv4_address(ipv4, p))
 {}

--- a/src/net/stack.cc
+++ b/src/net/stack.cc
@@ -190,7 +190,7 @@ socket_address::socket_address(const ipv6_addr& addr)
     std::copy(addr.ip.begin(), addr.ip.end(), u.in6.sin6_addr.s6_addr);
 }
 
-socket_address::socket_address(const ud_addr& addr)
+socket_address::socket_address(const unix_domain_addr& addr)
 {
     u.un.sun_family = AF_UNIX;
     
@@ -200,7 +200,7 @@ socket_address::socket_address(const ud_addr& addr)
     strncpy(u.un.sun_path, addr.sfile_.c_str(), sizeof(u.un.sun_path)-1);
     u.un.sun_path[sizeof(u.un.sun_path)-1] = '\0';
 }
-    
+
 socket_address::socket_address(uint32_t ipv4, uint16_t p)
     : socket_address(make_ipv4_address(ipv4, p))
 {}
@@ -208,6 +208,10 @@ socket_address::socket_address(uint32_t ipv4, uint16_t p)
 bool socket_address::operator==(const socket_address& a) const {
     if (u.sa.sa_family != a.u.sa.sa_family) {
         return false;
+    }
+    if (u.sa.sa_family == AF_UNIX) {
+        // no support yet for abstract-namespace u.d. sockets
+        return !strcmp(u.un.sun_path, a.u.un.sun_path);
     }
     if (u.in.sin_port != a.u.in.sin_port) {
         return false;


### PR DESCRIPTION
Adding server-side support for UNIX-domain stream sockets (used by the admin console).
Implementation note:
A third 'transport' option was added to the existing TCP & SCTP.

Note: no support for abstract-namespace sockets. As A.N. sockets save us the need to handle the clean-up of the created filesystem objects, I plan to add required support in a future pull request.

(new version will be pushed shortly)