### PR TITLE
future: don't spawn temporaries when extracting result

### DIFF
--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -368,7 +368,7 @@ struct future_state :  public future_state_base, private internal::uninitialized
         assert(_u.st == state::result);
         return this->uninitialized_get();
     }
-    std::tuple<T...> take() && {
+    std::tuple<T...>&& take() && {
         assert(_u.st != state::future);
         if (_u.st >= state::exception_min) {
             // Move ex out so future::~future() knows we've handled it
@@ -377,7 +377,7 @@ struct future_state :  public future_state_base, private internal::uninitialized
         _u.st = state::result_unavailable;
         return std::move(this->uninitialized_get());
     }
-    std::tuple<T...> get() && {
+    std::tuple<T...>&& get() && {
         assert(_u.st != state::future);
         if (_u.st >= state::exception_min) {
             // Move ex out so future::~future() knows we've handled it
@@ -385,7 +385,7 @@ struct future_state :  public future_state_base, private internal::uninitialized
         }
         return std::move(this->uninitialized_get());
     }
-    std::tuple<T...> get() const& {
+    const std::tuple<T...>& get() const& {
         assert(_u.st != state::future);
         if (_u.st >= state::exception_min) {
             std::rethrow_exception(_u.ex);
@@ -971,7 +971,14 @@ public:
     /// then it need not be available; instead, the thread will
     /// be paused until the future becomes available.
     [[gnu::always_inline]]
-    std::tuple<T...> get() {
+    std::tuple<T...> get() & {
+        if (!_state.available()) {
+            do_wait();
+        }
+        return get_available_state().take();
+    }
+    [[gnu::always_inline]]
+    std::tuple<T...>&& get() && {
         if (!_state.available()) {
             do_wait();
         }

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -407,6 +407,11 @@ struct future_state :  public future_state_base, private internal::uninitialized
         }
         _u.st = state::invalid;
     }
+    void ignore_result() noexcept {
+        if (_u.st == state::result) {
+            _u.st = state::result_unavailable;
+        }
+    }
     using get0_return_type = typename internal::get0_return_type<T...>::type;
     static get0_return_type get0(std::tuple<T...>&& x) {
         return internal::get0_return_type<T...>::get0(std::move(x));
@@ -1119,7 +1124,7 @@ public:
     /// \param func - function to be called when the future becomes available,
     /// \return a \c future representing the return value of \c func, applied
     ///         to the eventual value of this future.
-    template <typename Func, typename Result = futurize_t<std::result_of_t<Func(future)>>>
+    template <typename Func, typename Result = futurize_t<std::result_of_t<Func(future&&)>>>
     GCC6_CONCEPT( requires ::seastar::CanApply<Func, future> )
     Result
     then_wrapped(Func&& func) noexcept {
@@ -1135,12 +1140,17 @@ public:
 
 private:
 
-    template <typename Func, typename Result = futurize_t<std::result_of_t<Func(future)>>>
+    template <typename Func, typename Result = futurize_t<std::result_of_t<Func(future&&)>>>
     Result
     then_wrapped_impl(Func&& func) noexcept {
-        using futurator = futurize<std::result_of_t<Func(future)>>;
+        using futurator = futurize<std::result_of_t<Func(future&&)>>;
         if (available() && !need_preempt()) {
-            return futurator::apply(std::forward<Func>(func), future(get_available_state()));
+            if (_promise) {
+              detach_promise();
+            }
+            auto futret = futurator::apply(std::forward<Func>(func), std::move(*this));
+            _state.ignore_result();
+            return futret;
         }
         typename futurator::type fut(future_for_get_promise_marker{});
         // If there is a std::bad_alloc in schedule() there is nothing that can be done about it, we cannot break future

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -234,8 +234,9 @@ struct future_state_base {
     enum class state : uintptr_t {
          invalid = 0,
          future = 1,
-         result = 2,
-         exception_min = 3,  // or anything greater
+         result_unavailable = 2,
+         result = 3,
+         exception_min = 4,  // or anything greater
     };
     union any {
         any() { st = state::future; }
@@ -325,14 +326,16 @@ struct future_state :  public future_state_base, private internal::uninitialized
     future_state() noexcept {}
     [[gnu::always_inline]]
     future_state(future_state&& x) noexcept : future_state_base(std::move(x)) {
-        if (_u.st == state::result) {
+        // NOTE: this could be just `_u.st & state::result_unavailable` + static assert.
+        // I hope compiler will notice this on its own.
+        if (_u.st == state::result || _u.st == state::result_unavailable) {
             this->uninitialized_set(std::move(x.uninitialized_get()));
             x.uninitialized_get().~tuple();
         }
     }
     __attribute__((always_inline))
     ~future_state() noexcept {
-        if (_u.st == state::result) {
+        if (_u.st == state::result || _u.st == state::result_unavailable) {
             this->uninitialized_get().~tuple();
         }
     }
@@ -355,10 +358,24 @@ struct future_state :  public future_state_base, private internal::uninitialized
         assert(_u.st == state::result);
         return std::move(this->uninitialized_get());
     }
+    std::tuple<T...>&& take_value() && noexcept {
+        assert(_u.st == state::result);
+        _u.st = state::result_unavailable;
+        return std::move(this->uninitialized_get());
+    }
     template<typename U = std::tuple<T...>>
     const std::enable_if_t<std::is_copy_constructible<U>::value, U>& get_value() const& noexcept(copy_noexcept) {
         assert(_u.st == state::result);
         return this->uninitialized_get();
+    }
+    std::tuple<T...> take() && {
+        assert(_u.st != state::future);
+        if (_u.st >= state::exception_min) {
+            // Move ex out so future::~future() knows we've handled it
+            std::rethrow_exception(std::move(*this).get_exception());
+        }
+        _u.st = state::result_unavailable;
+        return std::move(this->uninitialized_get());
     }
     std::tuple<T...> get() && {
         assert(_u.st != state::future);
@@ -380,6 +397,7 @@ struct future_state :  public future_state_base, private internal::uninitialized
         case state::invalid:
         case state::future:
             assert(0 && "invalid state for ignore");
+        case state::result_unavailable:
         case state::result:
             this->~future_state();
             break;
@@ -952,7 +970,7 @@ public:
         if (!_state.available()) {
             do_wait();
         }
-        return get_available_state().get();
+        return get_available_state().take();
     }
 
     [[gnu::always_inline]]
@@ -1065,7 +1083,7 @@ private:
             if (failed()) {
                 return futurator::make_exception_future(get_available_state().get_exception());
             } else {
-                return futurator::apply(std::forward<Func>(func), get_available_state().get_value());
+                return futurator::apply(std::forward<Func>(func), get_available_state().take_value());
             }
         }
         typename futurator::type fut(future_for_get_promise_marker{});

--- a/include/seastar/core/future.hh
+++ b/include/seastar/core/future.hh
@@ -351,12 +351,12 @@ struct future_state :  public future_state_base, private internal::uninitialized
         new (this) future_state(ready_future_marker(), std::forward<A>(a)...);
     }
     future_state(exception_future_marker m, std::exception_ptr&& ex) : future_state_base(std::move(ex)) { }
-    std::tuple<T...> get_value() && noexcept {
+    std::tuple<T...>&& get_value() && noexcept {
         assert(_u.st == state::result);
         return std::move(this->uninitialized_get());
     }
     template<typename U = std::tuple<T...>>
-    std::enable_if_t<std::is_copy_constructible<U>::value, U> get_value() const& noexcept(copy_noexcept) {
+    const std::enable_if_t<std::is_copy_constructible<U>::value, U>& get_value() const& noexcept(copy_noexcept) {
         assert(_u.st == state::result);
         return this->uninitialized_get();
     }
@@ -885,7 +885,7 @@ private:
     }
 
     [[gnu::always_inline]]
-    future_state<T...> get_available_state() noexcept {
+    future_state<T...>&& get_available_state() noexcept {
         if (_promise) {
             detach_promise();
         }


### PR DESCRIPTION
Summary
=======
These patches squeeze unnecessary moving that happens when an object hold inside `future` is being extracted. The burden is especially visible when such objects are big or have complex move semantic (like our `bufferlist`). Please refer to the commit messages for details.

4 kB random read testing
==================
All numbers are in cycles/operation. Measured on Intel(R) Core(TM) i7-6820HQ CPU @ 2.70GHz (dev's laptop).

ceph branch            | seastar branch                          | Average| run 0| 1   | 2   | 3   | 4   | 5   | 6   | 7   | 8   | 9
-----------------------|-----------------------------------------|--------| -----|-----|-----|-----|-----|-----|-----|-----|-----|-----
`master`               | `master`                                |62097   | 60374|66741|62010|62217|61001|64153|60305|60854|62527|60793
`master`               | `wip-avoid_future_state_materialization`|57596   | 58437|56264|57191|58774|57375|56782|57996|57306|57908|57923


where the branches are:
* ceph: `804458bf51d672c58fe3cb0cb33d91c185ac73e9`,
* seastar:
    * `master`: `89a85fdd7b357d8cf55a392f312401a12a135a94`,
    * `wip-avoid_future_state_materialization`: 91050f6ffea6ede234c142ec2bc9363a239e5a2e.