### PR TITLE
Use actual URL for dpdk submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "dpdk"]
 	path = dpdk
-	url = ../dpdk
+	url = https://github.com/ceph/dpdk
 [submodule "fmt"]
 	path = fmt
 	url = ../fmt


### PR DESCRIPTION
The seastar submodule looks for dpdk but since https://github.com/ceph/ceph/commit/cb8087dfac31b8490fefdfca28d389b7b9901ef8, we no longer build it during ceph.git's submodule init.

Signed-off-by: David Galloway <dgallowa@redhat.com>